### PR TITLE
Update Set-JitLeastPrivilegedRole.ps1

### DIFF
--- a/Powershell scripts/JIT Scripts/JIT Custom Role/Set-JitLeastPrivilegedRole.ps1
+++ b/Powershell scripts/JIT Scripts/JIT Custom Role/Set-JitLeastPrivilegedRole.ps1
@@ -72,6 +72,7 @@ $role.Actions.Clear()
 $role.Actions.Add("Microsoft.Security/locations/jitNetworkAccessPolicies/read")
 $role.Actions.Add("Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action")
 $role.Actions.Add("Microsoft.Security/policies/read")
+$role.Actions.Add("Microsoft.Network/publicIPAddresses/read")
 if (!($forApiOnly))
 {
 	$role.Actions.Add("Microsoft.Compute/virtualMachines/read")


### PR DESCRIPTION
New RP action required
`Microsoft.Network/publicIPAddresses/read`
Previously covered by `Microsoft.Network/*/read` but new change separated the actions.

[What permissions are needed to configure and use JIT?](https://docs.microsoft.com/en-us/azure/defender-for-cloud/just-in-time-access-overview#what-permissions-are-needed-to-configure-and-use-jit) -> “Request JIT access to a VM“ section should be updated accordingly (WIP).


