### PR TITLE
Update README.md

### DIFF
--- a/Kusto/Azure Resource Graph/Starter Kit - ASC Pricing/README.md
+++ b/Kusto/Azure Resource Graph/Starter Kit - ASC Pricing/README.md
@@ -1,6 +1,6 @@
-# Starter Kit - ARG Queries for Azure Security Center Pricing
+# Starter Kit - ARG Queries for Microsoft Defender for Cloud Pricing
 Azure Resource Graph (ARG) provides an efficient way to query at scale across a given set of subscriptions for any Azure Resource (for more information please visit https://docs.microsoft.com/en-us/azure/governance/resource-graph/). 
-A useful use case is to use ARG to query, visualize or export Azure Security Center (ASC) Pricing information across your subscriptions in order to get the information that matters most to you.
+A useful use case is to use ARG to query, visualize or export Microsoft Defender for Cloud (MDFC) Pricing information across your subscriptions in order to get the information that matters most to you.
 
 This starter kit consists of a set of basic ARG queries that have been created to help you build on top of them based on your different needs and requirements.
 
@@ -11,7 +11,7 @@ resourcecontainers
 | count
 ```
 
-2. **How many of these subscriptions have been onboarded to ASC?**
+2. **How many of these subscriptions have been onboarded to MDFC?**
 ```
 securityresources
 | where type == "microsoft.security/pricings"
@@ -19,7 +19,7 @@ securityresources
 | count
 ```
 
-3. **How many of these subscriptions have not yet been onboarded to ASC?**
+3. **How many of these subscriptions have not yet been onboarded to MDFC?**
 ```
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
@@ -33,7 +33,7 @@ resourcecontainers
                 | count
 ```
 
-4. **Which subscriptions have not yet been onboarded to ASC?**
+4. **Which subscriptions have not yet been onboarded to MDFC?**
 ```
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
@@ -47,18 +47,7 @@ resourcecontainers
                 | project subscriptionId
 ```
 
-5. **Which subscriptions are using ASC with Azure Defender fully enabled?**
-```
-securityresources
- | where type == "microsoft.security/pricings"
- | project name, pricingTier=properties.pricingTier, subscriptionId
- | summarize count() by subscriptionId, tostring(pricingTier)
- | where pricingTier == 'Standard' and count_ == 10
- | project subscriptionId
-
-```
-
-6. **Which subscriptions are using ASC without Azure Defender fully enabled?**
+5. **Which subscriptions are using MDFC without the Defender plans fully enabled?**
 ```
 securityresources
 | where type == "microsoft.security/pricings"
@@ -66,22 +55,51 @@ securityresources
 | distinct subscriptionId
 ```
 
-7.  **What is the coverage (On | On (partial) | Off) for Azure Defender across all of my subscriptions?**
+6.  **What is the coverage (On | On (partial) | Off) for Microsoft Defender for Cloud across all of my subscriptions?**
 ```
 securityresources
-| where type == "microsoft.security/pricings"
-| summarize count() by subscriptionId,  pricingTier=tostring(properties.pricingTier)
-| extend Azure_Defender = case(
-                  pricingTier == 'Standard' and count_ == 10, "On", 
-                  pricingTier == 'Standard', "On (partial)", 
-                  pricingTier == 'Free' and count_ == 10, "Off", 
-                  '')
-| project subscriptionId, Azure_Defender
-| where isnotempty(Azure_Defender)
-| sort by Azure_Defender
+| where type =~ "microsoft.security/pricings"
+| extend  planSet = pack(name,pricingTier = properties.pricingTier)
+| summarize defenderPlans = make_bag(planSet) by subscriptionId
+| extend MDFC = case(  
+    defenderPlans.VirtualMachines == 'Standard' and 
+        defenderPlans.AppServices == 'Standard' and
+        defenderPlans.SqlServers == 'Standard' and
+        defenderPlans.SqlServerVirtualMachines == 'Standard' and 
+        defenderPlans.OpenSourceRelationalDatabases == 'Standard' and 
+        defenderPlans.CosmosDbs == 'Standard' and 
+        defenderPlans.StorageAccounts == 'Standard' and  
+        defenderPlans.Containers == 'Standard' and  
+        defenderPlans.KeyVaults == 'Standard' and 
+        defenderPlans.Arm == 'Standard' and 
+        defenderPlans.Dns == 'Standard', "On",
+     defenderPlans.VirtualMachines == 'Standard' or 
+        defenderPlans.AppServices == 'Standard' or
+        defenderPlans.SqlServers == 'Standard' or
+        defenderPlans.SqlServerVirtualMachines == 'Standard' or 
+        defenderPlans.OpenSourceRelationalDatabases == 'Standard' or 
+        defenderPlans.CosmosDbs == 'Standard' or 
+        defenderPlans.StorageAccounts == 'Standard' or  
+        defenderPlans.Containers == 'Standard' or  
+        defenderPlans.KeyVaults == 'Standard' or 
+        defenderPlans.Arm == 'Standard' or 
+        defenderPlans.Dns == 'Standard', "On (partial)",
+      defenderPlans.VirtualMachines == 'Free' and
+        defenderPlans.AppServices == 'Free' or
+        defenderPlans.SqlServers == 'Free' or
+        defenderPlans.SqlServerVirtualMachines == 'Free' and
+        defenderPlans.OpenSourceRelationalDatabases == 'Free' and
+        defenderPlans.CosmosDbs == 'Free' and
+        defenderPlans.StorageAccounts == 'Free' and 
+        defenderPlans.Containers == 'Free' and 
+        defenderPlans.KeyVaults == 'Free' and
+        defenderPlans.Arm == 'Free' and
+        defenderPlans.Dns == 'Free', "Off",
+    '')
+| project subscriptionId, MDFC
 ```
 
-8. **Which Azure Defender plans (Azure Defender for VMs, Azure Defender for KeyVaults, etc.) are enabled across all of my subscriptions?**
+7. **Which Defender plans (Microsoft Defender for Servers, Microsoft Defender for Key Vaults, etc.) are enabled across all of my subscriptions?**
 ```
 securityresources 
 | where type == "microsoft.security/pricings"

--- a/Kusto/Azure Resource Graph/Starter Kit - ASC Pricing/README.md
+++ b/Kusto/Azure Resource Graph/Starter Kit - ASC Pricing/README.md
@@ -1,6 +1,6 @@
 # Starter Kit - ARG Queries for Microsoft Defender for Cloud Pricing
 Azure Resource Graph (ARG) provides an efficient way to query at scale across a given set of subscriptions for any Azure Resource (for more information please visit https://docs.microsoft.com/en-us/azure/governance/resource-graph/). 
-A useful use case is to use ARG to query, visualize or export Microsoft Defender for Cloud (MDFC) Pricing information across your subscriptions in order to get the information that matters most to you.
+A useful use case is to use ARG to query, visualize or export Microsoft Defender for Cloud Pricing information across your subscriptions in order to get the information that matters most to you.
 
 This starter kit consists of a set of basic ARG queries that have been created to help you build on top of them based on your different needs and requirements.
 
@@ -11,7 +11,7 @@ resourcecontainers
 | count
 ```
 
-2. **How many of these subscriptions have been onboarded to MDFC?**
+2. **How many of these subscriptions have been onboarded to Defender for Cloud?**
 ```
 securityresources
 | where type == "microsoft.security/pricings"
@@ -19,7 +19,7 @@ securityresources
 | count
 ```
 
-3. **How many of these subscriptions have not yet been onboarded to MDFC?**
+3. **How many of these subscriptions have not yet been onboarded to Defender for Cloud?**
 ```
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
@@ -33,7 +33,7 @@ resourcecontainers
                 | count
 ```
 
-4. **Which subscriptions have not yet been onboarded to MDFC?**
+4. **Which subscriptions have not yet been onboarded to Defender for Cloud?**
 ```
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
@@ -47,7 +47,7 @@ resourcecontainers
                 | project subscriptionId
 ```
 
-5. **Which subscriptions are using MDFC without the Defender plans fully enabled?**
+5. **Which subscriptions are using Defender for Cloud without the Defender plans fully enabled?**
 ```
 securityresources
 | where type == "microsoft.security/pricings"
@@ -55,13 +55,13 @@ securityresources
 | distinct subscriptionId
 ```
 
-6.  **What is the coverage (On | On (partial) | Off) for Microsoft Defender for Cloud across all of my subscriptions?**
+6.  **What is the coverage (On | On (partial) | Off) for Defender for Cloud across all of my subscriptions?**
 ```
 securityresources
 | where type =~ "microsoft.security/pricings"
 | extend  planSet = pack(name,pricingTier = properties.pricingTier)
 | summarize defenderPlans = make_bag(planSet) by subscriptionId
-| extend MDFC = case(  
+| extend Defender_for_Cloud = case(  
     defenderPlans.VirtualMachines == 'Standard' and 
         defenderPlans.AppServices == 'Standard' and
         defenderPlans.SqlServers == 'Standard' and
@@ -96,7 +96,7 @@ securityresources
         defenderPlans.Arm == 'Free' and
         defenderPlans.Dns == 'Free', "Off",
     '')
-| project subscriptionId, MDFC
+| project subscriptionId, Defender_for_Cloud
 ```
 
 7. **Which Defender plans (Microsoft Defender for Servers, Microsoft Defender for Key Vaults, etc.) are enabled across all of my subscriptions?**


### PR DESCRIPTION
- Changed names from Azure Security Center and Azure Defender to Microsoft Defender for Cloud throughout
- Deleted number 5 - "which subscriptions are using ASC with Azure Defender fully enabled" as it does not return correct results due to count_ == 10 no longer reflecting the current number of Defender plans. To keep this accurate, we would need to ensure it is updated every time a new Defender plan is released, even though number 6 gives a more accurate reflection of MDFC coverage.
- Changed "What is the coverage (On | On (partial) | Off) for Microsoft Defender for Cloud across all of my subscriptions?" to get rid of count that is inaccurate with current plans to reflect the current MDFC plans