### PR TITLE
Updated outdated aksVersion from 1.21.9 to 1.24.3

### DIFF
--- a/Labs/Files/labdeploy.json
+++ b/Labs/Files/labdeploy.json
@@ -74,7 +74,7 @@
         "sqlServerName": "[toLower(concat('asclab-sql-',uniqueString(subscription().subscriptionId)))]",
         "sqlDatabaseName": "asclab-db",
         "aksClusterName": "asclab-aks",
-        "aksVersion": "1.21.9",
+        "aksVersion": "1.24.3",
         "aksDNSPrefix": "asclab-aks",
         "aksNetworkPlugin": "kubenet"
     },


### PR DESCRIPTION
updated labdeploy.json to use aksVersion:1.24.3 to be able to succsessfully deploy the lab environment.