### PR TITLE
Integration Settings Scripts

### DIFF
--- a/Powershell scripts/Integration Settings/enable-integration-settings.ps1
+++ b/Powershell scripts/Integration Settings/enable-integration-settings.ps1
@@ -1,0 +1,137 @@
+<#
+  .DESCRIPTION
+  This script will update Defender for Cloud's integrations settings on a subscription and enable Defender for Servers P1 or P2 if desired.
+
+  .PARAMETER subscriptionId
+  The id of the subscription to update settings for
+
+  .PARAMETER DefenderforServersPlan
+  The Defender for Servers Plan to Enable. Accepted values are P1, P2, Disabled, or Current. By default the current plan is used.
+
+  .PARAMETER DefenderforCloudApps
+  Enable the Defender for Cloud Apps Integration. Default is set to true.
+
+  .PARAMETER DefenderforEndpoint
+  Enable the Defender for Endpoint Integration. Default is set to true.
+
+  .PARAMETER DefenderforEndpointExcludeLinux
+  Exclude Linux Endpoints from Defender for Endpoint. Default is set to false. *Note this setting is only available for subscriptions where the legacy preview may still be enabled.
+
+  .PARAMETER DefenderforEndpointUnifiedAgent
+  Enable the Defender for Endpoint Unified Agent. Default is set to true.
+
+  .PARAMETER SentinelBiDirectionalAlertSync
+  Enable the Sentinel Bi-Directional Alert Sync. Default is set to true.
+
+  .EXAMPLE
+  Enable with all reccomended settings: Defender for Servers current plan, Defender for Endpoint Integration, Defender for Cloud Apss Integration, Unified Agent, Include Linux Servers
+  .\enable-integration-settings.ps1 -subscriptionId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90'
+
+  .EXAMPLE
+  Enable with all reccomended settings on multiple subscriptions
+  Get-AzSubscription | % {.\enable-integration-settings.ps1 -subscriptionId $_.id}
+
+  .EXAMPLE
+  Enable with all reccomended settings and Defender for Servers P1
+  .\enable-integration-settings.ps1 -subscriptionId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90' -DefenderforServersPlan 'P1'
+#>
+
+param(
+    [Parameter(ValueFromPipeline = $true, Mandatory=$true)]
+    [string]$subscriptionId,
+    
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("P1", "P2", "Disabled", "Current")]
+    [string]$DefenderforServersPlan = 'Current',
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$DefenderforCloudApps = $true,
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$DefenderforEndpoint = $true,
+    
+    [Parameter(Mandatory = $false)]
+    [boolean]$DefenderforEndpointExcludeLinux = $false,
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$DefenderforEndpointUnifiedAgent = $true,
+
+    [Parameter(Mandatory = $false)]
+    [boolean]$SentinelBiDirectionalAlertSync = $true
+)
+
+$subscription = Get-AzSubscription -SubscriptionId $subscriptionId
+
+Write-Host ('Updating Settings for subscription {0}' -f $subscription.Name)
+
+#Set Defender for Endpoint Integration
+$payload = (@{
+    kind = 'DataExportSettings'
+    properties = @{
+        enabled = $DefenderforEndpoint
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -Name 'WDATP' -ApiVersion '2022-05-01' -Method PUT -Payload $payload
+Write-Host ('Configured Defender for Endpoint Integration on Subscription: {0}; Enabled: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.enabled)
+
+#Set Defender for Endpoint Linux Agent
+$payload = (@{
+    kind = 'DataExportSettings'
+    properties = @{
+        enabled = $DefenderforEndpointExcludeLinux
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -Name 'WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW' -ApiVersion '2022-05-01' -Method PUT -Payload $payload
+Write-Host ('Configured Exclude Linux Servers from Defender for Endpoint on Subscription: {0}; Enabled: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.enabled)
+
+#Set Defender for Endpoint Unified Agent
+$payload = (@{
+    kind = 'DataExportSettings'
+    properties = @{
+        enabled = $DefenderforEndpointUnifiedAgent
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -Name 'WDATP_UNIFIED_SOLUTION' -ApiVersion '2022-05-01' -Method PUT -Payload $payload
+Write-Host ('Configured Defender for Endpoint Unified Agent on Subscription: {0}; Enabled: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.enabled)
+
+#Set Defender for Cloud Apps Integration
+$payload = (@{
+    kind = 'DataExportSettings'
+    properties = @{
+        enabled = $DefenderforCloudApps
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -Name 'MCAS' -ApiVersion '2022-05-01' -Method PUT -Payload $payload
+Write-Host ('Configured Defender for Cloud Apps Integration on Subscription: {0}; Enabled: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.enabled)
+
+#Set Defender For Servers Plan
+$payload = (@{
+    properties = @{
+        pricingTier = $(If($DefenderforServersPlan -like 'Disabled'){'Free'}else{'Standard'})
+        subPlan = $(If($DefenderforServersPlan -like 'Disabled'){$null}
+        elseif ($DefenderforServersPlan -like 'Current') {
+            $currentPlan = (Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'pricings' -Name 'VirtualMachines' -ApiVersion '2022-03-01' -Method Get).Content | ConvertFrom-Json
+            If ($currentPlan.properties.subPlan){$currentPlan.properties.subPlan}
+            else{$null}
+        }
+        else{$DefenderforServersPlan})
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'pricings' -Name 'VirtualMachines' -ApiVersion '2022-03-01' -Method PUT -Payload $payload
+Write-Host ('Configured Defender for Servers Plan on Subscription: {0}; Plan: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.subPlan)
+
+#Set Sentinel Bi-directional Alert Sync
+$payload = (@{
+    kind = 'AlertSyncSettings'
+    properties = @{
+        enabled = $SentinelBiDirectionalAlertSync
+    }
+}) | ConvertTo-Json
+
+$results = Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -Name 'Sentinel' -ApiVersion '2022-05-01' -Method PUT -Payload $payload
+Write-Host ('Configured Sentinel Bi-Directional Alert Sync on Subscription: {0}; Enabled: {1}' -f $subscription.Name, ($results.Content | ConvertFrom-Json).properties.enabled)

--- a/Powershell scripts/Integration Settings/get-integration-report.ps1
+++ b/Powershell scripts/Integration Settings/get-integration-report.ps1
@@ -1,0 +1,62 @@
+<#
+  .DESCRIPTION
+  This script will report on all integration settings for all subscriptins in Defender for Cloud and provide the current Defender for Servers Plan
+  
+  .PARAMETER TenantId
+  The TenantId to gather all subscriptions under. If no TenantId is specified the current Tenant will be returned from Get-AzContext
+
+  .EXAMPLE
+  Get all subscription integration settings for the currently connected Tenant
+  $settings = .\get-integration-report.ps1
+
+  .EXAMPLE
+  Get all subscription integration settings for a specific Tenant
+  $settings = .\get-integration-report.ps1 -TenantId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90'
+ #>
+
+ param(
+    [Parameter(ValueFromPipeline = $true, Mandatory=$false)]
+    [string]$TenantId
+ )
+
+#Get All Subscriptions
+If($TenantId){
+    $subscriptions = Get-AzSubscription -TenantId $TenantId | Where State -eq 'Enabled'
+}else{    
+    $subscriptions = Get-AzSubscription -TenantId (Get-AzContext).Tenant | Where State -eq 'Enabled'
+}
+
+$friendlysettings = @()
+
+ForEach ($subscription in $subscriptions){
+    $settings = ((Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'settings' -ApiVersion '2022-05-01' -Method Get).Content | ConvertFrom-Json).Value
+    $defenderForServersPlan = (Invoke-AzRestMethod -SubscriptionId $subscription.Id -ResourceProviderName 'Microsoft.Security' -ResourceType 'pricings' -Name 'VirtualMachines' -ApiVersion '2022-03-01' -Method Get).Content | ConvertFrom-Json
+    Write-Host ('Getting Settings for subscription {0}' -f $subscription.Name)
+    if($settings){
+        $friendlysettings += ([PSCustomObject]@{
+            subscriptionName = $subscription.Name
+            subscriptionId = $subscription.Id
+            DefenderforServersPlan = $(if($defenderForServersPlan.properties.subPlan -eq $null){'notenabled'}else{$defenderForServersPlan.properties.subPlan})
+            DefenderforCloudApps = ($settings | where name -eq 'MCAS').Properties.enabled
+            DefenderforEndpoint = ($settings | where name -eq 'WDATP').Properties.enabled
+            DefenderforEndpointExcludeLinux = ($settings | where name -eq 'WDATP_EXCLUDE_LINUX_PUBLIC_PREVIEW').Properties.enabled
+            DefenderforEndpointUnifiedAgent = ($settings | where name -eq 'WDATP_UNIFIED_SOLUTION').Properties.enabled
+            SentinelBiDirectionalAlertSync = ($settings | where name -eq 'Sentinel').Properties.enabled
+            error = $null
+        })
+    }else{
+        $friendlysettings += ([PSCustomObject]@{
+            subscriptionName = $subscription.Name
+            subscriptionId = $subscription.Id
+            DefenderforServersPlan = 'no settings returned'
+            DefenderforCloudApps = 'no settings returned'
+            DefenderforEndpoint = 'no settings returned'
+            DefenderforEndpointExcludeLinux = 'no settings returned'
+            DefenderforEndpointUnifiedAgent = 'no settings returned'
+            SentinelBiDirectionalAlertSync = 'no settings returned'
+            error = ('No Settings Returned for Subscription: {0}, you may not have security reader rights assigned' -f $subscription.Name)
+        })
+    }
+}
+
+$friendlysettings

--- a/Powershell scripts/Integration Settings/readme.md
+++ b/Powershell scripts/Integration Settings/readme.md
@@ -1,0 +1,71 @@
+# Integration Settings Scripts
+
+- [Overview](#overview)
+- [get-integration-report](#get-integration-report)
+- [enable-integration-settings](#enable-integration-settings)
+
+## Overview
+These scripts will allow you to report and update integration settings in Defender for Cloud for multiple subscriptions. 
+
+## get-integration-report
+
+get-integration-report.ps1 script will report on:
+- Defender for Servers Plan
+- Defender for Cloud Apps Integration
+- Defender for Endpoint Integration
+- Defender for Endpoint Unified Agent
+- Defender for Endpoint: Exclude Linux Servers Public Preview Flag
+- Sentinel Bi-Directional Alert Sync Settings
+
+### Running the Script
+
+```powershell
+# Get all subscription integration settings for the currently connected Tenant
+$settings = .\get-integration-report.ps1
+$settings | Export-CSV integration-settings.csv
+```
+
+```powershell
+Get all subscription integration settings for a specific Tenant
+$settings = .\get-integration-report.ps1 -TenantId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90'
+$settings | Export-CSV integration-settings.csv
+```
+
+## enable-integration-settings
+
+enable-integration-settings.ps1 will update:
+- Defender for Servers Plan
+- Defender for Cloud Apps Integration
+- Defender for Endpoint Integration
+- Defender for Endpoint Unified Agent
+- Defender for Endpoint: Exclude Linux Servers Public Preview Flag
+- Sentinel Bi-Directional Alert Sync Settings
+
+### Default Settings
+> The script will impose the following default settings unless specified
+
+| Feature | Setting |
+| ------- | ------- |
+| Defender for Servers Plan | Current Subscription Setting |
+| Defender for Cloud Apps Integration | Enabled |
+| Defender for Endpoint Integration | Enabled |
+| Defender for Endpoint Unified Agent | Enabled |
+| Defender for Endpoint: Exclude Linux Servers Public Preview Flag | Disabled |
+| Sentinel Bi-Directional Alert Sync Settings | Enabled |
+
+### Running the Script
+
+```powershell
+# Enable with all reccomended settings: Defender for Servers current plan, Defender for Endpoint Integration, Defender for Cloud Apss Integration, Unified Agent, Include Linux Servers
+.\enable-integration-settings.ps1 -subscriptionId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90'
+```
+
+```powershell
+# Enable with all reccomended settings on multiple subscriptions
+Get-AzSubscription | % {.\enable-integration-settings.ps1 -subscriptionId $_.id}
+```
+
+```powershell
+#  Enable with all reccomended settings and Defender for Servers P1
+.\enable-integration-settings.ps1 -subscriptionId 'c94dffc7-2dd9-4750-a3de-a160ddd68c90' -DefenderforServersPlan 'P1'
+``` 


### PR DESCRIPTION
These scripts will allow you to report and update integration settings in Defender for Cloud for multiple subscriptions.

**get-integration-report.ps1 script will report on:**

Defender for Servers Plan
Defender for Cloud Apps Integration
Defender for Endpoint Integration
Defender for Endpoint Unified Agent
Defender for Endpoint: Exclude Linux Servers Public Preview Flag
Sentinel Bi-Directional Alert Sync Settings

**enable-integration-settings.ps1 will update:**

Defender for Servers Plan
Defender for Cloud Apps Integration
Defender for Endpoint Integration
Defender for Endpoint Unified Agent
Defender for Endpoint: Exclude Linux Servers Public Preview Flag
Sentinel Bi-Directional Alert Sync Settings