### PR TITLE
replaced Azure Security Benchmark name with the new name

### DIFF
--- a/Labs/Modules/Module-4-Regulatory-Compliance.md
+++ b/Labs/Modules/Module-4-Regulatory-Compliance.md
@@ -12,7 +12,7 @@ This exercise guides you through the current Microsoft Defender for Cloud polici
 
 1.	From **Microsoft Defender for Cloud main dashboard**, select **Regulatory Compliance** tile (this pilar is also available from the sidebar under Cloud Security).
 2.	Regulatory Compliance dashboard opens. On this page, you can see the compliance standards currently assigned to your subscription.
-3.	On the top strip, notice the number of **passed controls** for Azure Security Benchmark.
+3.	On the top strip, notice the number of **passed controls** for Microsoft cloud security benchmark.
 
 ### Exercise 2: Adding new standards
 
@@ -35,7 +35,7 @@ You can add additional industry standards (represented as compliance packages) s
 ### Exercise 3: Exploring a benchmark 
 1.	From the top menu bar in Regulatory Compliance, select **Manage compliance policies** which can be found next to **Download report**, above the **Lowest compliance regulatory standards** tile.
 2. Then select your subscription and choose **Security Policy** from the sidebar.
-3.	On the **Industry & regulatory standards** section, notice the out of the box standards like Azure Security Benchmark, PCI DSS 3.2.1 and ISO 27001.
+3.	On the **Industry & regulatory standards** section, notice the out of the box standards like Microsoft cloud security benchmark, PCI DSS 3.2.1 and ISO 27001.
 4.	Locate the **PCI DSS 3.2.1** standard and select **Enable**.
 ![Regulatory compliance assessment and standards](../Images/mdfc-pci.png?raw=true)
 5. Select **yes** to the pop-up asking you to enable PCI DSS.

--- a/Labs/Modules/Module-5-Improving-your-Secure-Posture.md
+++ b/Labs/Modules/Module-5-Improving-your-Secure-Posture.md
@@ -10,14 +10,14 @@ This exercise guides you how to use the vulnerability assessment for virtual mac
 
 ### Exercise 1: Vulnerability assessment for VMs
 
-With Microsoft Defender for Cloud for servers, you can quickly deploy the integrated vulnerability assessment solution (powered by Qualys) with no additional configuration or extra costs. Once the vulnerability assessment scanner is deployed, it continually assesses all the installed applications on a virtual machine to find vulnerabilities and presents its findings in the Microsoft Defender for Cloud console. When a machine is found that doesn't have *vulnerability* assessment solution deployed, Microsoft Defender for Cloud generates a recommendation: *A vulnerability assessment solution should be enabled on your virtual machines*. To remediate a resource, you can click on the Quick Fix button to deploy the necessary VM extension.
+With Microsoft Defender for Cloud for servers, you can quickly deploy the integrated vulnerability assessment solution (powered by Qualys) with no additional configuration or extra costs. Once the vulnerability assessment scanner is deployed, it continually assesses all the installed applications on a virtual machine to find vulnerabilities and presents its findings in the Microsoft Defender for Cloud console. When a machine is found that doesn't have *vulnerability* assessment solution deployed, Microsoft Defender for Cloud generates a recommendation: *Machines should have a vulnerability assessment solution*. To remediate a resource, you can click on the Quick Fix button to deploy the necessary VM extension.
 
 **Explore vulnerability assessment recommendations:**
 
 1.	From Microsoft Defender for Cloud sidebar, click on **Recommendations**.
 2.	Expend **Remediate vulnerabilities** security control (which contains all recommendations related to security vulnerabilities).
-3.	Make sure you have *A vulnerability assessment solution should be enabled on your virtual machines* recommendation. If you don’t have this recommendation on the list, you will probably need 24 hours to have the recommendation with the assessment.
-4.	Open the **A vulnerability assessment solution should be enabled on your virtual machines” recommendation** – this recommendation is a Quick Fix one which allows you to deploy the VM extension on the desired VMs.
+3.	Make sure you have *Machines should have a vulnerability assessment solution* recommendation. If you don’t have this recommendation on the list, you will probably need 24 hours to have the recommendation with the assessment.
+4.	Open the **Machines should have a vulnerability assessment solution” recommendation** – this recommendation is a Quick Fix one which allows you to deploy the VM extension on the desired VMs.
 5.	Expend **Remediation steps** – in addition to the Quick Fix remediation option, you can also use the **view quick fix logic** option to expose an automatic remediation script content (ARM template). **Close this window.**
 6.	From the unhealthy tab, select both *asclab-win* and *aslab-linux* virtual machines. Click **Fix**.
 7.	On the **Choose a vulnerability assessment solution** select **Recommended: Deploy ASC integrated vulnerability scanner powered by Qualys (included in Microsoft Defender for Cloud for servers)**. Click **Proceed**.
@@ -30,8 +30,8 @@ With Microsoft Defender for Cloud for servers, you can quickly deploy the integr
     - From Azure Portal, open **Virtual Machines**.
     - Select **asclab-win**.
     - From the sidebar, click on **Extensions**.
-    - Make sure to have `WindowsAgent.AzureSecurityCenter` extension installed and successfully provisioned.
-    - Repeat the process for **asclab-linux** – you should expect to see a different name for the extension on Linux platform: LinuxAgent.AzureSecurityCenter.
+    - Make sure to have `MDE.Windows` extension installed and successfully provisioned.
+    - Repeat the process for **asclab-linux** – you should expect to see a different name for the extension on Linux platform: `MDE.Linux`.
 
 > Note: There are multiple ways you can automate the process where you need to achieve at scale deployment. More details are available on our [documentation](https://docs.microsoft.com/en-us/azure/security-center/deploy-vulnerability-assessment-vm#automate-at-scale-deployments) and on [blog](https://techcommunity.microsoft.com/t5/azure-security-center/built-in-vulnerability-assessment-for-vms-in-azure-security/ba-p/1577947).
 
@@ -41,7 +41,7 @@ With Microsoft Defender for Cloud for servers, you can quickly deploy the integr
 
 1.	From Microsoft Defender for Cloud sidebar, click on **Recommendations**.
 2.	Expend **Remediate vulnerabilities** security control (which contains all recommendations related to security vulnerabilities).
-3.	Search for **Vulnerabilities in your virtual machines should be remediated**.
+3.	Search for **Machines should have vulnerability findings resolved**.
 4.	On the Security Checks, you should see a list of vulnerabilities found on the affected resources.
 5.	On the recommendation, expend **Affected resources**. You should see two unhealthy resources (asclab-win and asclab-linux) and not applicable resources.
 6.	From the **Unhealthy resources**, select **asclab-win** resource. Here you can view all relevant recommendations for that resource.


### PR DESCRIPTION
In the portal it is no longer named Azure Security Benchmark but rather Microsoft cloud security benchmark, I have simply proposed to rename it so beginners following this guide does not get confused as they may not know of the name change that took place. 