### PR TITLE
Clear defender tags for versioned blobs

### DIFF
--- a/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags.ps1
+++ b/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags.ps1
@@ -183,17 +183,11 @@ foreach ($storageAccount in $storageAccounts) {
         do {
             Write-Host "`t`t`tFetching blobs from container '$containerName' in storage account '$($storageAccount.StorageAccountName)'"
             try {
-                $blobs = Get-AzStorageBlob -Container $container.Name -Context $context -IncludeVersion -IncludeTag -MaxCount $batchSize -ContinuationToken $token
-                $eligibleBlobs = $blobs | Where-Object {  $_.Tags -ne $null -and $_.Tags.ContainsKey($tagScanTimeUTC) -and $_.Tags[$tagScanTimeUTC] -gt $cutoffDate }
-
-                if ($blobs -eq $null -or $blobs.Count -eq 0) {
+                $eligibleBlobs = Get-AzStorageBlobByTag -TagFilterSqlExpression $filterExpression -Context $context -MaxCount $batchSize -ContinuationToken $token
+                Write-Host "`t`t`t`tRetrieved $($eligibleBlobs.Count) eligible blobs"
+                if ($eligibleBlobs -eq $null -or $eligibleBlobs.Count -eq 0) {
                     Break
                 }
-
-                # Update the continuation token for the next batch
-                $token = $blobs[-1].ContinuationToken
-
-                Write-Host "`t`t`t`tRetrieved $($blobs.Count) out of which $($eligibleBlobs.Count) are eligible"
             } catch {
                 Write-Host "`t`t`t`tError accessing blobs in container '$containerName' of storage account '$($storageAccount.StorageAccountName)'. Skipping this container."
                 Break
@@ -202,19 +196,19 @@ foreach ($storageAccount in $storageAccounts) {
             # Process each blob in the current batch
             foreach ($blob in $eligibleBlobs) {
                 $identifiedBlobs++
-                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name), Version: $($blob.VersionId)' in container '$containerName'"
+                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name)' in container '$containerName'"
 
                 try {
-                    $tags = $blob.Tags
-                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name), Version: $($blob.VersionId)'"
+                    $tags = Get-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name
+                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name)'"
                 } catch {
-                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name), Version: $($blob.VersionId)'. Skipping this blob."
+                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name)'. Skipping this blob."
                     continue
                 }
 
                 if ($tags[$tagScanResult] -eq "Malicious") {
                     $maliciousBlobsCount++
-                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name), Version: $($blob.VersionId)' is malicious. Keeping the tags."
+                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name)' is malicious. Keeping the tags."
 
                 } else {
                     # Remove specific index tags if they exist
@@ -230,19 +224,21 @@ foreach ($storageAccount in $storageAccounts) {
 
                     if ($tagRemoved) {
                         try {
-                            Set-AzStorageBlobTag -Context $context -BlobBaseClient $blob.BlobBaseClient -Tag $tags
+                            Set-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name -Tag $tags
                             $removedTagsCount++
-                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name), Version: $($blob.VersionId)'"
+                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name)'"
                         } catch {
-                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)', Version: $($blob.VersionId). Skipping this blob."
+                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)'. Skipping this blob."
                         }
                     }
                 }
             }
 
+            # Update the continuation token for the next batch
+            $token = $eligibleBlobs.ContinuationToken
             Write-Host ""
 
-        } while ($null -ne $token)
+        } while ($null -eq $token)
     }
 	$scannedStorageAccounts++
 }

--- a/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags.ps1
+++ b/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags.ps1
@@ -183,11 +183,17 @@ foreach ($storageAccount in $storageAccounts) {
         do {
             Write-Host "`t`t`tFetching blobs from container '$containerName' in storage account '$($storageAccount.StorageAccountName)'"
             try {
-                $eligibleBlobs = Get-AzStorageBlobByTag -TagFilterSqlExpression $filterExpression -Context $context -MaxCount $batchSize -ContinuationToken $token
-                Write-Host "`t`t`t`tRetrieved $($eligibleBlobs.Count) eligible blobs"
-                if ($eligibleBlobs -eq $null -or $eligibleBlobs.Count -eq 0) {
+                $blobs = Get-AzStorageBlob -Container $container.Name -Context $context -IncludeVersion -IncludeTag -MaxCount $batchSize -ContinuationToken $token
+                $eligibleBlobs = $blobs | Where-Object {  $_.Tags -ne $null -and $_.Tags.ContainsKey($tagScanTimeUTC) -and $_.Tags[$tagScanTimeUTC] -gt $cutoffDate }
+
+                if ($blobs -eq $null -or $blobs.Count -eq 0) {
                     Break
                 }
+
+                # Update the continuation token for the next batch
+                $token = $blobs[-1].ContinuationToken
+
+                Write-Host "`t`t`t`tRetrieved $($blobs.Count) out of which $($eligibleBlobs.Count) are eligible"
             } catch {
                 Write-Host "`t`t`t`tError accessing blobs in container '$containerName' of storage account '$($storageAccount.StorageAccountName)'. Skipping this container."
                 Break
@@ -196,19 +202,19 @@ foreach ($storageAccount in $storageAccounts) {
             # Process each blob in the current batch
             foreach ($blob in $eligibleBlobs) {
                 $identifiedBlobs++
-                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name)' in container '$containerName'"
+                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name), Version: $($blob.VersionId)' in container '$containerName'"
 
                 try {
-                    $tags = Get-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name
-                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name)'"
+                    $tags = $blob.Tags
+                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name), Version: $($blob.VersionId)'"
                 } catch {
-                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name)'. Skipping this blob."
+                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name), Version: $($blob.VersionId)'. Skipping this blob."
                     continue
                 }
 
                 if ($tags[$tagScanResult] -eq "Malicious") {
                     $maliciousBlobsCount++
-                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name)' is malicious. Keeping the tags."
+                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name), Version: $($blob.VersionId)' is malicious. Keeping the tags."
 
                 } else {
                     # Remove specific index tags if they exist
@@ -224,21 +230,19 @@ foreach ($storageAccount in $storageAccounts) {
 
                     if ($tagRemoved) {
                         try {
-                            Set-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name -Tag $tags
+                            Set-AzStorageBlobTag -Context $context -BlobBaseClient $blob.BlobBaseClient -Tag $tags
                             $removedTagsCount++
-                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name)'"
+                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name), Version: $($blob.VersionId)'"
                         } catch {
-                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)'. Skipping this blob."
+                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)', Version: $($blob.VersionId). Skipping this blob."
                         }
                     }
                 }
             }
 
-            # Update the continuation token for the next batch
-            $token = $eligibleBlobs.ContinuationToken
             Write-Host ""
 
-        } while ($null -eq $token)
+        } while ($null -ne $token)
     }
 	$scannedStorageAccounts++
 }

--- a/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags_Vrsions.ps1
+++ b/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags_Vrsions.ps1
@@ -6,7 +6,7 @@
 
 .DESCRIPTION
     This script connects to an Azure subscription, scans specified or all storage accounts, identifies versioned blobs with malware scanning tags, and removes those tags if the blobs are not malicious.
-    It will not delete tags from latest blobs. For that use the script RemoveMalwareScanningTags.ps1.
+    It will not delete tags from latest blobs. For that use the script RemoveMalwareScanningIndexTags.ps1.
 
 .PARAMETER SubscriptionId
     The ID of the Azure subscription to scan.
@@ -42,9 +42,9 @@
 
 # Example:
 # To run this script, you can use the following command to scan a specific storage account:
-# .\RemoveMalwareScanningIndexTags.ps1 -SubscriptionId "your-subscription-id" -ResourceGroupName "your-resource-group" -StorageAccountName "your-storage-account-name" -DaysThreshold 7
+# .\RemoveMalwareScanningIndexTags_Vrsions.ps1 -SubscriptionId "your-subscription-id" -ResourceGroupName "your-resource-group" -StorageAccountName "your-storage-account-name" -DaysThreshold 7
 # or scan an entire subscription:
-# .\RemoveMalwareScanningIndexTags.ps1 -SubscriptionId "your-subscription-id" -DaysThreshold 7
+# .\RemoveMalwareScanningIndexTags_Vrsions.ps1 -SubscriptionId "your-subscription-id" -DaysThreshold 7
 #>
 
 param(

--- a/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags_Vrsions.ps1
+++ b/Powershell scripts/Remove Malware Scanning Index Tags/RemoveMalwareScanningIndexTags_Vrsions.ps1
@@ -2,11 +2,11 @@
 
 <#
 .SYNOPSIS
-    This script scans Azure Storage accounts for blobs with malware scanning tags and removes them from non-malicious blobs.
+    This script scans Azure Storage accounts for blobs with malware scanning tags and removes them from non-malicious versioned blobs.
 
 .DESCRIPTION
-    This script connects to an Azure subscription, scans specified or all storage accounts, identifies blobs with malware scanning tags, and removes those tags if the blobs are not malicious.
-    It will not delete tags from versioned blobs. For that use script RemoveMalwareScanningIndexTags_Vrsions.ps1
+    This script connects to an Azure subscription, scans specified or all storage accounts, identifies versioned blobs with malware scanning tags, and removes those tags if the blobs are not malicious.
+    It will not delete tags from latest blobs. For that use the script RemoveMalwareScanningTags.ps1.
 
 .PARAMETER SubscriptionId
     The ID of the Azure subscription to scan.
@@ -21,7 +21,7 @@
     (Optional) The number of days to use as the threshold for recent blobs. Default is 7 days.
 
 .NOTES
-    Author: Eitan Shteinberg
+    Author: Eitan Shteinberg, Varun Garg
     Version: 1.0
     Date: 2024-06-02
 
@@ -184,11 +184,17 @@ foreach ($storageAccount in $storageAccounts) {
         do {
             Write-Host "`t`t`tFetching blobs from container '$containerName' in storage account '$($storageAccount.StorageAccountName)'"
             try {
-                $eligibleBlobs = Get-AzStorageBlobByTag -TagFilterSqlExpression $filterExpression -Context $context -MaxCount $batchSize -ContinuationToken $token
-                Write-Host "`t`t`t`tRetrieved $($eligibleBlobs.Count) eligible blobs"
-                if ($eligibleBlobs -eq $null -or $eligibleBlobs.Count -eq 0) {
+                $blobs = Get-AzStorageBlob -Container $container.Name -Context $context -IncludeVersion -IncludeTag -MaxCount $batchSize -ContinuationToken $token
+                $eligibleBlobs = $blobs | Where-Object { !$_.IsLatestVersion -and $_.Tags -ne $null -and $_.Tags.ContainsKey($tagScanTimeUTC) -and $_.Tags[$tagScanTimeUTC] -gt $cutoffDate }
+
+                if ($blobs -eq $null -or $blobs.Count -eq 0) {
                     Break
                 }
+
+                # Update the continuation token for the next batch
+                $token = $blobs[-1].ContinuationToken
+
+                Write-Host "`t`t`t`tRetrieved $($blobs.Count) out of which $($eligibleBlobs.Count) are eligible"
             } catch {
                 Write-Host "`t`t`t`tError accessing blobs in container '$containerName' of storage account '$($storageAccount.StorageAccountName)'. Skipping this container."
                 Break
@@ -197,19 +203,19 @@ foreach ($storageAccount in $storageAccounts) {
             # Process each blob in the current batch
             foreach ($blob in $eligibleBlobs) {
                 $identifiedBlobs++
-                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name)' in container '$containerName'"
+                Write-Host "`t`t`t`t`tProcessing blob '$($blob.Name), Version: $($blob.VersionId)' in container '$containerName'"
 
                 try {
-                    $tags = Get-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name
-                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name)'"
+                    $tags = $blob.Tags
+                    Write-Host "`t`t`t`t`t`tRetrieved tags for blob '$($blob.Name), Version: $($blob.VersionId)'"
                 } catch {
-                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name)'. Skipping this blob."
+                    Write-Host "`t`t`t`t`t`tError retrieving tags for blob '$($blob.Name), Version: $($blob.VersionId)'. Skipping this blob."
                     continue
                 }
 
                 if ($tags[$tagScanResult] -eq "Malicious") {
                     $maliciousBlobsCount++
-                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name)' is malicious. Keeping the tags."
+                    Write-Host "`t`t`t`t`t`The blob '$($blob.Name), Version: $($blob.VersionId)' is malicious. Keeping the tags."
 
                 } else {
                     # Remove specific index tags if they exist
@@ -225,21 +231,19 @@ foreach ($storageAccount in $storageAccounts) {
 
                     if ($tagRemoved) {
                         try {
-                            Set-AzStorageBlobTag -Context $context -Container $containerName -Blob $blob.Name -Tag $tags
+                            Set-AzStorageBlobTag -Context $context -BlobBaseClient $blob.BlobBaseClient -Tag $tags
                             $removedTagsCount++
-                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name)'"
+                            Write-Host "`t`t`t`t`t`t`Removed index tags from blob '$($blob.Name), Version: $($blob.VersionId)'"
                         } catch {
-                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)'. Skipping this blob."
+                            Write-Host "`t`t`t`t`t`t`Error setting tags for blob '$($blob.Name)', Version: $($blob.VersionId). Skipping this blob."
                         }
                     }
                 }
             }
 
-            # Update the continuation token for the next batch
-            $token = $eligibleBlobs.ContinuationToken
             Write-Host ""
 
-        } while ($null -eq $token)
+        } while ($null -ne $token)
     }
 	$scannedStorageAccounts++
 }


### PR DESCRIPTION
This update will allow customers clear defender tags from prior versions of blobs (excluding the latest ones).